### PR TITLE
Align repositories with updated models

### DIFF
--- a/Repositories/MatchesRepo.cs
+++ b/Repositories/MatchesRepo.cs
@@ -13,9 +13,13 @@ namespace VLeague.Repositories
             var list = new List<Match>();
             using (var cmd = Conn.CreateCommand())
             {
-                cmd.CommandText = @"SELECT MATCH_ID, ROUND, MATCH_DAY, STADIUM, TOURNAMENT,
-                                           HOME_TEAM, AWAY_TEAM, HOME_COLOR, AWAY_COLOR
-                                    FROM MATCHES ORDER BY MATCH_ID DESC;";
+                cmd.CommandText = @"SELECT m.MATCH_ID, m.ROUND, m.MATCH_DAY, m.STADIUM, m.TOURNAMENT,
+                                           m.HOME_TEAM, m.AWAY_TEAM, m.HOME_COLOR, m.AWAY_COLOR,
+                                           ht.TEAMS_FULL_NAME AS HOME_NAME, at.TEAMS_FULL_NAME AS AWAY_NAME
+                                    FROM MATCHES m
+                                    LEFT JOIN TEAM_ID ht ON ht.TEAM_ID = m.HOME_TEAM
+                                    LEFT JOIN TEAM_ID at ON at.TEAM_ID = m.AWAY_TEAM
+                                    ORDER BY m.MATCH_ID DESC;";
                 using (var rd = cmd.ExecuteReader())
                 {
                     while (rd.Read())
@@ -31,9 +35,13 @@ namespace VLeague.Repositories
         {
             using (var cmd = Conn.CreateCommand())
             {
-                cmd.CommandText = @"SELECT MATCH_ID, ROUND, MATCH_DAY, STADIUM, TOURNAMENT,
-                                           HOME_TEAM, AWAY_TEAM, HOME_COLOR, AWAY_COLOR
-                                    FROM MATCHES WHERE MATCH_ID=@id;";
+                cmd.CommandText = @"SELECT m.MATCH_ID, m.ROUND, m.MATCH_DAY, m.STADIUM, m.TOURNAMENT,
+                                           m.HOME_TEAM, m.AWAY_TEAM, m.HOME_COLOR, m.AWAY_COLOR,
+                                           ht.TEAMS_FULL_NAME AS HOME_NAME, at.TEAMS_FULL_NAME AS AWAY_NAME
+                                    FROM MATCHES m
+                                    LEFT JOIN TEAM_ID ht ON ht.TEAM_ID = m.HOME_TEAM
+                                    LEFT JOIN TEAM_ID at ON at.TEAM_ID = m.AWAY_TEAM
+                                    WHERE m.MATCH_ID=@id;";
                 cmd.Parameters.AddWithValue("@id", matchId);
                 using (var rd = cmd.ExecuteReader())
                 {
@@ -98,6 +106,8 @@ namespace VLeague.Repositories
             m.AWAY_TEAM = rd.IsDBNull(6) ? 0 : rd.GetInt32(6);
             m.HOME_COLOR = rd.IsDBNull(7) ? null : rd.GetString(7);
             m.AWAY_COLOR = rd.IsDBNull(8) ? null : rd.GetString(8);
+            m.HOME_NAME = rd.IsDBNull(9) ? null : rd.GetString(9);
+            m.AWAY_NAME = rd.IsDBNull(10) ? null : rd.GetString(10);
             return m;
         }
     }

--- a/Repositories/TacticalRepo.cs
+++ b/Repositories/TacticalRepo.cs
@@ -22,24 +22,26 @@ INSERT INTO TACTICAL(MATCH_ID, TEAM_ID, TACTICAL_TEXT) VALUES(@mid, @tid, @txt);
             }
         }
 
-        public Dictionary<int, string> ByMatch(int matchId)
+        public List<TacticalItem> ByMatch(int matchId)
         {
-            var dict = new Dictionary<int, string>();
+            var list = new List<TacticalItem>();
             using (var cmd = Conn.CreateCommand())
             {
-                cmd.CommandText = @"SELECT TEAM_ID, TACTICAL_TEXT FROM TACTICAL WHERE MATCH_ID=@mid;";
+                cmd.CommandText = @"SELECT MATCH_ID, TEAM_ID, TACTICAL_TEXT FROM TACTICAL WHERE MATCH_ID=@mid ORDER BY TEAM_ID;";
                 cmd.Parameters.AddWithValue("@mid", matchId);
                 using (var rd = cmd.ExecuteReader())
                 {
                     while (rd.Read())
                     {
-                        var teamId = rd.GetInt32(0);
-                        var txt = rd.IsDBNull(1) ? null : rd.GetString(1);
-                        dict[teamId] = txt;
+                        var item = new TacticalItem();
+                        item.MATCH_ID = rd.GetInt32(0);
+                        item.TEAM_ID = rd.GetInt32(1);
+                        item.TACTICAL_TEXT = rd.IsDBNull(2) ? null : rd.GetString(2);
+                        list.Add(item);
                     }
                 }
             }
-            return dict;
+            return list;
         }
     }
 }


### PR DESCRIPTION
## Summary
- include team name lookups when reading matches so Match models populate HOME_NAME and AWAY_NAME
- return tactical data as TacticalItem objects, filling all model fields

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d2c14b25488321a2bfb5c3034d2f0c