### PR TITLE
Add centralized DataManager caching for match data

### DIFF
--- a/Session/DataManager.cs
+++ b/Session/DataManager.cs
@@ -1,14 +1,18 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
-using System.Data.SQLite;
+using System.Linq;
+using VLeague.Data;
 using VLeague.Models;
 using VLeague.Repositories;
-using VLeague.Data;
 
 namespace VLeague.Session
 {
     public static class DataManager
     {
+        private static readonly object SyncRoot = new object();
+
+        private static int? _currentMatchId;
+
         // Cache dữ liệu để tái sử dụng
         public static List<Team> Teams { get; private set; }
         public static List<HomePlayer> HomePlayers { get; private set; }
@@ -21,13 +25,147 @@ namespace VLeague.Session
         // Clear cache khi chuyển trận khác
         public static void ClearCache()
         {
-            Teams = null;
-            HomePlayers = null;
-            AwayPlayers = null;
-            Officials = null;
-            Weather = null;
-            Tactical = null;
-            Scenes = null;
+            lock (SyncRoot)
+            {
+                Teams = null;
+                HomePlayers = null;
+                AwayPlayers = null;
+                Officials = null;
+                Weather = null;
+                Tactical = null;
+                Scenes = null;
+                _currentMatchId = null;
+            }
+        }
+
+        public static IReadOnlyList<Team> GetTeams()
+        {
+            EnsureCommonDataLoaded();
+            return Teams;
+        }
+
+        public static Team GetTeam(int teamId)
+        {
+            EnsureCommonDataLoaded();
+            return Teams?.FirstOrDefault(t => t.TEAM_ID == teamId);
+        }
+
+        public static IReadOnlyList<SceneItem> GetScenes()
+        {
+            EnsureCommonDataLoaded();
+            return Scenes;
+        }
+
+        public static IReadOnlyList<HomePlayer> GetHomePlayers(int matchId)
+        {
+            EnsureMatchDataLoaded(matchId);
+            return HomePlayers;
+        }
+
+        public static IReadOnlyList<AwayPlayer> GetAwayPlayers(int matchId)
+        {
+            EnsureMatchDataLoaded(matchId);
+            return AwayPlayers;
+        }
+
+        public static IReadOnlyList<Official> GetOfficials(int matchId)
+        {
+            EnsureMatchDataLoaded(matchId);
+            return Officials;
+        }
+
+        public static IReadOnlyList<WeatherItem> GetWeather(int matchId)
+        {
+            EnsureMatchDataLoaded(matchId);
+            return Weather;
+        }
+
+        public static IReadOnlyList<TacticalItem> GetTactical(int matchId)
+        {
+            EnsureMatchDataLoaded(matchId);
+            return Tactical;
+        }
+
+        public static void LoadMatchData(int matchId)
+        {
+            EnsureMatchDataLoaded(matchId);
+        }
+
+        private static void EnsureCommonDataLoaded()
+        {
+            if (Teams != null && Scenes != null) return;
+
+            lock (SyncRoot)
+            {
+                if (Teams != null && Scenes != null) return;
+
+                var conn = Db.GetConnection();
+
+                if (Teams == null)
+                {
+                    var teamsRepo = new TeamsRepo(conn);
+                    Teams = teamsRepo.GetAll();
+                }
+
+                if (Scenes == null)
+                {
+                    var scenesRepo = new ScenesRepo(conn);
+                    Scenes = scenesRepo.GetAll();
+                }
+            }
+        }
+
+        private static void EnsureMatchDataLoaded(int matchId)
+        {
+            if (_currentMatchId == matchId &&
+                HomePlayers != null &&
+                AwayPlayers != null &&
+                Officials != null &&
+                Weather != null &&
+                Tactical != null)
+            {
+                return;
+            }
+
+            lock (SyncRoot)
+            {
+                if (_currentMatchId != matchId)
+                {
+                    HomePlayers = null;
+                    AwayPlayers = null;
+                    Officials = null;
+                    Weather = null;
+                    Tactical = null;
+                }
+
+                if (HomePlayers != null &&
+                    AwayPlayers != null &&
+                    Officials != null &&
+                    Weather != null &&
+                    Tactical != null &&
+                    _currentMatchId == matchId)
+                {
+                    return;
+                }
+
+                EnsureCommonDataLoaded();
+
+                var conn = Db.GetConnection();
+
+                var homeRepo = new HomePlayersRepo(conn);
+                var awayRepo = new AwayPlayersRepo(conn);
+                var officialsRepo = new OfficialsRepo(conn);
+                var weatherRepo = new WeatherRepo(conn);
+                var tacticalRepo = new TacticalRepo(conn);
+
+                HomePlayers = homeRepo.List(matchId);
+                AwayPlayers = awayRepo.List(matchId);
+                Officials = officialsRepo.ByMatch(matchId);
+                Weather = weatherRepo.ByMatch(matchId);
+                Tactical = tacticalRepo.ByMatch(matchId);
+
+                _currentMatchId = matchId;
+            }
         }
     }
 }

--- a/UI/SetupUC.cs
+++ b/UI/SetupUC.cs
@@ -198,7 +198,7 @@ namespace VLeague
                 DataManager.ClearCache();
 
                 // Load tất cả dữ liệu cho trận mới
-                //DataManager.LoadMatchData(matchId);
+                DataManager.LoadMatchData(matchId);
 
                 MessageBox.Show("Đã load xong dữ liệu trận đấu!", "Thành công");
             }


### PR DESCRIPTION
## Summary
- add a thread-safe DataManager that lazily loads and caches teams, match participants, and scene data from repositories
- update the setup workflow to invoke the new DataManager loader when a match is selected

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d3615686a08321882391bba4a52c8c